### PR TITLE
警告メッセージを改良

### DIFF
--- a/chrome_extension/javascripts/background.js
+++ b/chrome_extension/javascripts/background.js
@@ -38,7 +38,7 @@ function mainLoop() {
         stayNgSiteSeconds++;
         switch (stayNgSiteSeconds) {
         case ALERT_TIME:
-            alert("あと" + (TWEET_TIME - ALERT_TIME) + "秒ニコニコ動画に滞在するとTwitterに報告されます " + new Date().toString());
+            alert("あと" + (TWEET_TIME - ALERT_TIME) + "秒このサイトに滞在するとTwitterに報告されます " + new Date().toString());
             break;
         case TWEET_TIME:
             chrome.tabs.update(currentTab.id, {url: "chrome://newtab/"});


### PR DESCRIPTION
ニコニコ動画以外でも「これ以上ニコニコ動画に滞在するとTwitterに報告する」という警告メッセージが表示されていたので、警告メッセージを意味が通るように改良した