### PR TITLE
警告メッセージ中の不要な日時表示を削除

### DIFF
--- a/chrome_extension/javascripts/background.js
+++ b/chrome_extension/javascripts/background.js
@@ -38,7 +38,7 @@ function mainLoop() {
         stayNgSiteSeconds++;
         switch (stayNgSiteSeconds) {
         case ALERT_TIME:
-            alert("あと" + (TWEET_TIME - ALERT_TIME) + "秒このサイトに滞在するとTwitterに報告されます " + new Date().toString());
+            alert("あと" + (TWEET_TIME - ALERT_TIME) + "秒このサイトに滞在するとTwitterに報告されます");
             break;
         case TWEET_TIME:
             chrome.tabs.update(currentTab.id, {url: "chrome://newtab/"});


### PR DESCRIPTION
日時表示はツイートの重複投稿エラー避けのためのもので、警告メッセージのalertには表示する必要が無いので削除した