### PR TITLE
ポップアップ内の案内メッセージをタイマーのオンオフに合わせて切り替える機能を追加

### DIFF
--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -11,18 +11,28 @@ $(() => {
             $("#end_button").parent().css("display", "none");
         }
     }
+    function refreshGuideMessage() {
+        if (!bg.isTimerOn) {
+            $(".guide_message").html("ボタンを押すと監視がはじまるよ！");
+        } else {
+            $(".guide_message").html("監視中");
+        }
+    }
 
     $("#start_button").click(() => {
         let time = Number($("#task_time_text").val()) * 60;
         if(isNaN(time) || time < 0) return false;
         bg.startTimer(time);
         flushButtonArea();
+        refreshGuideMessage();
     });
     $("#end_button").click(() => {
         let message = `${Math.round(bg.limitSeconds / 60)}分かかると見積もった作業を${Math.round(bg.elapsedSeconds / 60)}分で終えました! #UGEN ${new Date()}`;
         bg.tweet(message, () => { bg.alert("tweetしたよ^_^"); });
         bg.stopTimer();
         flushButtonArea();
+        refreshGuideMessage();
     });
     flushButtonArea();
+    refreshGuideMessage();
 });

--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -13,9 +13,9 @@ $(() => {
     }
     function refreshGuideMessage() {
         if (bg.isTimerOn) {
-            $("#guide_message").html("監視中");
+            $("#guide_message").text("監視中");
         } else {
-            $("#guide_message").html("ボタンを押すと監視がはじまるよ！");
+            $("#guide_message").text("ボタンを押すと監視がはじまるよ！");
         }
     }
 

--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -12,10 +12,10 @@ $(() => {
         }
     }
     function refreshGuideMessage() {
-        if (!bg.isTimerOn) {
-            $(".guide_message").html("ボタンを押すと監視がはじまるよ！");
+        if (bg.isTimerOn) {
+            $("#guide_message").html("監視中");
         } else {
-            $(".guide_message").html("監視中");
+            $("#guide_message").html("ボタンを押すと監視がはじまるよ！");
         }
     }
 

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="style.css" type="text/css">
 </head>
 <body>
-    <p>ボタンを押すと監視がはじまるよ！<br><img src="../images/ugenchan.png" alt=""></p>
+    <p class="guide_message">ボタンを押すと監視がはじまるよ！<br><img src="../images/ugenchan.png" alt=""></p>
     <p>
         <input type="text" value="10" id="task_time_text" size="3">分のタスクを<input type="button" value="開始" id="start_button">
     </p>

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -8,7 +8,10 @@
 <link rel="stylesheet" href="style.css" type="text/css">
 </head>
 <body>
-    <p class="guide_message">ボタンを押すと監視がはじまるよ！<br><img src="../images/ugenchan.png" alt=""></p>
+    <p id="guide_message">ボタンを押すと監視がはじまるよ！</p>
+    <p>
+        <img src="images/ugenchan.png" alt="">
+    </p>
     <p>
         <input type="text" value="10" id="task_time_text" size="3">分のタスクを<input type="button" value="開始" id="start_button">
     </p>

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="style.css" type="text/css">
 </head>
 <body>
-    <p id="guide_message">ボタンを押すと監視がはじまるよ！</p>
+    <p id="guide_message"></p>
     <p>
         <img src="images/ugenchan.png" alt="">
     </p>


### PR DESCRIPTION
タイマー起動中もポップアップ内に "ボタンを押すと監視がはじまるよ！" と書かれているせいで、
開始ボタンを押してもタイマーが動かないのではないか？ という誤解を生んでしまっていることがフィードバックから得られたので、
その誤解の原因を解消するために
タイマーのオンオフに合わせて案内メッセージもスイッチする機能を書いた
- [x] タイマーのオンオフに合わせて案内メッセージを変える