### PR TITLE
タスク失敗リプライを前もって受信の意向を示している人にのみ送るようにした

### DIFF
--- a/chrome_extension/background.html
+++ b/chrome_extension/background.html
@@ -6,9 +6,8 @@
 <script type="text/javascript" src="lib/jquery-1.11.3.min.js"></script>
 <script type="text/javascript" src="lib/sha1.js"></script>
 <script type="text/javascript" src="lib/oauth.js"></script>
-<script type="text/javascript" src="javascripts/mocking.js"></script>
-<script type="text/javascript" src="javascripts/consumer_key_and_secret.js"></script>
 <script type="text/javascript" src="javascripts/common.js"></script>
+<script type="text/javascript" src="javascripts/mocking.js"></script>
 <script type="text/javascript" src="javascripts/background.js"></script>
 </head>
 <body>

--- a/chrome_extension/config.html
+++ b/chrome_extension/config.html
@@ -7,9 +7,8 @@
 <script type="text/javascript" src="lib/bootstrap/bootstrap.min.js"></script>
 <script type="text/javascript" src="lib/sha1.js"></script>
 <script type="text/javascript" src="lib/oauth.js"></script>
-<script type="text/javascript" src="javascripts/mocking.js"></script>
-<script type="text/javascript" src="javascripts/consumer_key_and_secret.js"></script>
 <script type="text/javascript" src="javascripts/common.js"></script>
+<script type="text/javascript" src="javascripts/mocking.js"></script>
 <script type="text/javascript" src="javascripts/config.js"></script>
 <link rel="stylesheet" href="lib/bootstrap/bootstrap.min.css" type="text/css">
 </head>
@@ -32,10 +31,22 @@
             <form class="form-inline">
                 <div class="input-group">
                     <span class="input-group-addon">@</span>
-                    <input type="text" size="15" id="modify_account_text" class="form-control">
+                    <select id="modify_account_select" class="form-control">
+                    </select>
                 </div>
                 <input type="button" value="更新" id="modify_account_button" class="btn btn-primary">
             </form>
+        </div>
+        <div class="well">
+            <form class="form-inline">
+                <div class="input-group">
+                    <span class="input-group-addon">@</span>
+                    <input type="text" size="15" id="new_account_text" class="form-control">
+                </div>
+                <input type="button" value="新規追加" id="new_account_button" class="btn btn-primary">
+            </form>
+            新規追加ボタンを押すと @<span id="permission_message_destination"></span> に以下のリプライを送り許可待ち状態になります。
+            <blockquote id="permission_message"></blockquote>
         </div>
         <h2 class="sub-header">Twitter連携</h2>
         <p>

--- a/chrome_extension/javascripts/background.js
+++ b/chrome_extension/javascripts/background.js
@@ -6,6 +6,7 @@ var stayNgSiteSeconds;
 var taskDescription;
 var timerState = "off";
 var oneMinuteNotified = false;
+var wait = 1000;
 
 const ALERT_TIME = 5;
 const TWEET_TIME = 10;
@@ -14,41 +15,56 @@ let timerId;
 
 function mainLoop() {
     function next() {
-        timerId = setTimeout(mainLoop, 1000);
+        if (timerState == "on") timerId = setTimeout(mainLoop, wait);
     }
 
     elapsedSeconds++;
     let remainingSeconds = limitSeconds - elapsedSeconds;
     if (remainingSeconds > 60) {
-        chrome.browserAction.setBadgeText({"text": Math.ceil(remainingSeconds / 60).toString()});
+        chrome.browserAction.setBadgeText({text: Math.ceil(remainingSeconds / 60).toString()});
         chrome.browserAction.setBadgeBackgroundColor({color:[0, 0, 255, 100]});
     } else {
         if (!oneMinuteNotified){
             notificate("あと1分でtweetされます", 2);
             oneMinuteNotified = true;
         }
-        chrome.browserAction.setBadgeText({"text": Math.round(remainingSeconds).toString()});
+        chrome.browserAction.setBadgeText({text: Math.round(remainingSeconds).toString()});
         chrome.browserAction.setBadgeBackgroundColor({color:[255, 0, 0, 100]});
     }
     if (elapsedSeconds >= limitSeconds) {
-        tweet(generateTweet(
-            element => `@${localStorage.getItem("replyAccount")} 突然のリプライ失礼致します。このたび私事ながら${element}作業時間の見積もりに失敗しました。誠に申し訳ありません ${new Date()} #UGEN`,
-            {
-                element: taskDescription,
-                formatter(element, upperLimitLength, getShortenedString) {
-                    if (element == "") return "";
-                    if (element.length + 3 <= upperLimitLength) return `「${element}」の`;
-                    return `「${getShortenedString(6)}...」の`;
-                },
-            }
-        ), () => { alert("tweetしたよ^_^"); });
+        let replyAccountId = JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountId;
+        if (replyAccountId == -1) {
+            tweet(generateTweet(
+                element => `私は${element}作業時間の見積もりに失敗しました ${new Date()} #UGEN`,
+                {
+                    element: taskDescription,
+                    formatter(element, upperLimitLength, getShortenedString) {
+                        if (element == "") return "";
+                        if (element.length + 3 <= upperLimitLength) return `「${element}」の`;
+                        return `「${getShortenedString(6)}...」の`;
+                    }
+                }
+            )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });
+        } else {
+            getScreenName(replyAccountId).then(screenName => {
+                tweet(generateTweet(
+                    element => `@${screenName} 突然のリプライ失礼致します。このたび私事ながら${element}作業時間の見積もりに失敗しました。誠に申し訳ありません ${new Date()} #UGEN`,
+                    {
+                        element: taskDescription,
+                        formatter(element, upperLimitLength, getShortenedString) {
+                            if (element == "") return "";
+                            if (element.length + 3 <= upperLimitLength) return `「${element}」の`;
+                            return `「${getShortenedString(6)}...」の`;
+                        }
+                    }
+                )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });
+            });
+        }
         stopTimer();
         return;
     }
 
-    chrome.tabs.query({currentWindow: true, active: true}, tabs => {
-        if (tabs.length == 0) return next();
-        let currentTab = tabs[0];
+    getCurrentTab().then(currentTab => {
         if (!isNgSite(currentTab.url)) return next();
 
         stayNgSiteSeconds++;
@@ -66,16 +82,16 @@ function mainLoop() {
                             if (element == "") return "作業";
                             if (element.length + 2 <= upperLimitLength) return `「${element}」`;
                             return `「${getShortenedString(5)}...」`;
-                        },
+                        }
                     },
                     {
                         element: currentTab.title,
                         formatter(element, upperLimitLength, getShortenedString) {
                             if (element.length <= upperLimitLength) return element;
                             else return `${getShortenedString(3)}...`;
-                        },
+                        }
                     }
-                ), () => { alert("tweetしたよ^_^"); });
+                )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });;
             } else {
                 tweet(generateTweet(
                     element => `私は${element}をサボっていました ${new Date()} #UGEN`,
@@ -85,17 +101,18 @@ function mainLoop() {
                             if (element == "") return "作業";
                             if (element.length + 2 <= upperLimitLength) return `「${element}」`;
                             return `「${getShortenedString(5)}...」`;
-                        },
+                        }
                     }
-                ), () => { alert("tweetしたよ^_^"); });
+                )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });;
             }
             chrome.tabs.update(currentTab.id, {url: "chrome://newtab/"});
             stayNgSiteSeconds = 0;
             break;
         }
         next();
-    });
+    }).catch(e => { alert(e.message); });
 }
+
 function startTimer(limitSecondsAsParameter, taskDescriptionAsParameter) {
     if (timerState != "off") throw new Error("Illegal state.");
     limitSeconds = limitSecondsAsParameter;
@@ -103,7 +120,7 @@ function startTimer(limitSecondsAsParameter, taskDescriptionAsParameter) {
     stayNgSiteSeconds = -1;
     taskDescription = taskDescriptionAsParameter;
     timerState = "on";
-    chrome.browserAction.setIcon({path: "../images/watchicon16.png"});
+    chrome.browserAction.setIcon({path: "images/watchicon16.png"});
     oneMinuteNotified = false;
     mainLoop();
 }
@@ -111,14 +128,14 @@ function startTimer(limitSecondsAsParameter, taskDescriptionAsParameter) {
 function pauseTimer() {
     if (timerState != "on") throw new Error("Illegal state.");
     timerState = "pause";
-    chrome.browserAction.setIcon({path:"../images/icon16.png"});
+    chrome.browserAction.setIcon({path: "images/icon16.png"});
     clearTimeout(timerId);
 }
 
 function restartTimer() {
     if (timerState != "pause") throw new Error("Illegal state.");
     timerState = "on";
-    chrome.browserAction.setIcon({path: "../images/watchicon16.png"});
+    chrome.browserAction.setIcon({path: "images/watchicon16.png"});
     mainLoop();
 }
 
@@ -126,7 +143,7 @@ function stopTimer() {
     if (timerState != "on") throw new Error("Illegal state.");
     timerState = "off";
     chrome.browserAction.setBadgeText({"text": ""});
-    chrome.browserAction.setIcon({path:"../images/icon16.png"});
+    chrome.browserAction.setIcon({path: "images/icon16.png"});
     clearTimeout(timerId);
 }
 
@@ -137,115 +154,6 @@ function isNgSite(url) {
         if (url.match(re)) return true;
     }
     return false;
-}
-
-// 1個以上の文字数が不明な文字列を用いて140文字以内のツイートを作る、という問題の解決を助ける関数
-function generateTweet(baseMessageGenerator) {
-    let elementHolders = Array.from(arguments).slice(1);
-    // RFC3986定義の厳密なHTTP URIの正規表現
-    // http://sinya8282.sakura.ne.jp/?p=1064
-    let uriPattern = /https?:(\/\/(([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=])*@)?(\[(([0-9a-f]{1,4}:){6}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|::([0-9a-f]{1,4}:){5}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|([0-9a-f]{1,4})?::([0-9a-f]{1,4}:){4}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:)?[0-9a-f]{1,4})?::([0-9a-f]{1,4}:){3}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::([0-9a-f]{1,4}:){2}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(([0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::|v[0-9a-f]+\.[!$&-.0-;=_a-z~]+)\]|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])|([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,;=])*)(:\d*)?(\/([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])*)*|\/(([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])+(\/([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])*)*)?|([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])+(\/([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])*)*)?(\?([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,/:;=?@])*)?(#([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,/:;=?@])*)?/ig;
-    // 自由に使える文字数 = 140 - ベースとなる文字列の文字数
-    // URIはt.coで短縮されて23文字になるので考慮しておく
-    let freeLength = 140 - baseMessageGenerator(...new Array(baseMessageGenerator.length).fill("")).replace(uriPattern, "x".repeat(23)).length;
-    // 各文字数が不明な文字列が使える文字数の上限を割り振る
-    // 自由に使える文字数が74文字で、文字数が不明な文字列が3個ならば、[25文字, 25文字, 24文字]のように割り振る
-    let upperLimitLengths = new Array(elementHolders.length).fill()
-        .map((_, i) => Math.floor(freeLength / elementHolders.length) + (i < freeLength % elementHolders.length ? 1 : 0));
-    return baseMessageGenerator(...elementHolders.map((elementHolder, i) => {
-        // 文字数が不明な文字列中の@#をエスケープしてリプライ誤爆やハッシュタグ誤爆を防ぐ
-        let element = elementHolder.element.replace(/([@#＠＃])/g, "$1\u200c");
-        return elementHolder.formatter(
-            element,
-            upperLimitLengths[i],
-            // elementの先頭を、使える文字数の上限だけ切り取り、さらに末尾cutLength文字切った文字列を返す関数
-            // 末尾を切った結果、末尾が@#になってしまうと、リプライ誤爆やハッシュタグ誤爆を起こしかねないので、その際は末尾の@#も切る
-            cutLength => element.substring(0, upperLimitLengths[i] - cutLength).replace(/[@#＠＃]$/, "")
-        );
-    }));
-}
-
-function notificate(message, displaySeconds) {
-    let notification = new Notification(message, {
-        icon: "images/ugenchan.png"
-    });
-    if (displaySeconds > 0) {
-        setTimeout(() => {
-            notification.close();
-        }, displaySeconds * 1000);
-    }
-    let audio = new Audio();
-    audio.autoplay = true;
-    audio.src = "sounds/alert.wav";
-}
-
-function tweet(str, callBack){
-    let message = {
-        method: "POST",
-        action: "https://api.twitter.com/1.1/statuses/update.json",
-        parameters: {
-            status: str
-        }
-    };
-    let originalParameters = $.extend({}, message.parameters);
-    OAuth.completeRequest(message, {
-        consumerKey: CONSUMER_KEY,
-        consumerSecret: CONSUMER_SECRET,
-        token: localStorage.getItem("accessToken"),
-        tokenSecret: localStorage.getItem("accessTokenSecret")
-    });
-    $.ajax({
-        type: message.method,
-        url: message.action,
-        headers: {
-            "Authorization": OAuth.getAuthorizationHeader("", message.parameters)
-        },
-        data: OAuth.formEncode(originalParameters),
-        dataType: "json",
-        success: responseJson => {
-            if (callBack !== undefined) callBack();
-        },
-        error: responseObject => {
-            alert(`Error: ${responseObject.status} ${responseObject.statusText}\n${responseObject.responseText}`);
-        }
-    });
-};
-
-function searchTweets(str){
-  return new Promise(function(resolve, reject) {
-    let message = {
-        method: "GET",
-        action: "https://api.twitter.com/1.1/search/tweets.json",
-        parameters: {
-            q: str,
-            count: 100
-        }
-    };
-    let originalParameters = $.extend({}, message.parameters);
-    OAuth.completeRequest(message, {
-        consumerKey: CONSUMER_KEY,
-        consumerSecret: CONSUMER_SECRET,
-        token: localStorage.getItem("accessToken"),
-        tokenSecret: localStorage.getItem("accessTokenSecret")
-    });
-    $.ajax({
-        type: message.method,
-        url: message.action,
-        timeout: 30000,
-        headers: {
-            "Authorization": OAuth.getAuthorizationHeader("", message.parameters)
-        },
-        data: OAuth.formEncode(originalParameters),
-        dataType: "json",
-        success: responseJson => {
-            resolve(responseJson);
-        },
-        error: responseObject => {
-            alert(`Error: ${responseObject.status} ${responseObject.statusText}\n${responseObject.responseText}`);
-            reject(null);
-        }
-    });
-  });
 }
 
 function notifyRank(){
@@ -271,53 +179,19 @@ function notifyRank(){
       }).then(workTimeMap => {
           let myWorkTime = Math.round((elapsedSeconds / 60) + workTimeMap.get(Number(localStorage.getItem("userId"))));
           let myRank = [...workTimeMap.values()].filter(workTime => workTime > myWorkTime).length + 1;
-          new Notification(`今日のあなたの作業時間合計は${myWorkTime}分で、${workTimeMap.size}人中${myRank}位です！`);
+          notificate(`今日のあなたの作業時間合計は${myWorkTime}分で、${workTimeMap.size}人中${myRank}位です！`, 0);
       });
-}
-
-function readTimeline(id){
-    return new Promise(function(resolve, reject) {
-        let message = {
-            method: "GET",
-            action: "https://api.twitter.com/1.1/statuses/user_timeline.json",
-            parameters: {
-                user_id: id,
-                count: 1000
-            }
-        };
-        let originalParameters = $.extend({}, message.parameters);
-        OAuth.completeRequest(message, {
-            consumerKey: CONSUMER_KEY,
-            consumerSecret: CONSUMER_SECRET,
-            token: localStorage.getItem("accessToken"),
-            tokenSecret: localStorage.getItem("accessTokenSecret")
-        });
-        $.ajax({
-            type: message.method,
-            url: message.action,
-            timeout: 30000,
-            headers: {
-                "Authorization": OAuth.getAuthorizationHeader("", message.parameters)
-            },
-            data: OAuth.formEncode(originalParameters),
-            dataType: "json",
-            success: responseJson => {
-                resolve(responseJson);
-            },
-            error: responseObject => {
-                alert(`Error: ${responseObject.status} ${responseObject.statusText}\n${responseObject.responseText}`);
-                reject(null);
-            }
-        });
-    });
 }
 
 $(() => {
     if (localStorage.getItem("urlList") === null) {
         localStorage.setItem("urlList", JSON.stringify(["nicovideo.jp", "youtube.com"]));
     }
-    if (localStorage.getItem("replyAccount") === null) {
-        localStorage.setItem("replyAccount", "UGEN_teacher");
+    if (localStorage.getItem("replySetting") === null) {
+        localStorage.setItem("replySetting", JSON.stringify({}));
+    }
+    if (localStorage.getItem("screenNameMap") === null) {
+        localStorage.setItem("screenNameMap", JSON.stringify({}))
     }
     if (localStorage.getItem("showRegisterNgSiteButton") === "True") {
         $("#show_register_ngsite_button_checkbox").prop("checked", true);

--- a/chrome_extension/javascripts/common.js
+++ b/chrome_extension/javascripts/common.js
@@ -1,69 +1,164 @@
 "use strict";
 
-function createRegisterNgSiteButton(){
-  chrome.contextMenus.create({
-      "title": "現在のタブをNGサイトに登録",
-      "type" :"normal",
-      "id": "register_ngsite_button"
-  });
-  chrome.contextMenus.create({
-      "title": "現在のタブをNGサイトから除外",
-      "type" :"normal",
-      "id": "remove_ngsite_button"
-  });
-  chrome.contextMenus.onClicked.addListener(onRegisterNgSiteButtonClickHandler);
+function callTwitterApi(method, action, parameters, tokens) {
+    if (typeof(tokens) == "undefined") {
+        tokens = {
+            token: localStorage.getItem("accessToken"),
+            tokenSecret: localStorage.getItem("accessTokenSecret")
+        };
+    }
+    return new Promise((resolve, reject) => {
+        let getsToken = (action == "https://api.twitter.com/oauth/request_token" ||
+            action == "https://api.twitter.com/oauth/access_token");
+        let message = {
+            method: method,
+            action: action,
+            parameters: parameters
+        };
+        let originalParameters = $.extend({}, message.parameters);
+        OAuth.completeRequest(message, $.extend({
+            consumerKey: "mqnjswbYNsvfnwp8N3aoPs5TU",
+            consumerSecret: "dbaio9YDq5S1X3cL5AceWbFgsaADOaA9B8TrRU2TnDLlYZTVLP"
+        }, tokens));
+        $.ajax({
+            type: message.method,
+            url: message.action,
+            timeout: 30000,
+            headers: {
+                "Authorization": OAuth.getAuthorizationHeader("", message.parameters)
+            },
+            data: OAuth.formEncode(getsToken ? {} : originalParameters),
+            dataType: getsToken ? "text" : "json",
+            success: response => {
+                resolve(getsToken ? OAuth.getParameterMap(response) : response);
+            },
+            error: response => {
+                reject(new Error(`Could not call Twitter API (${response.status} ${response.statusText}): ${response.responseText}`));
+            }
+        });
+    });
+}
+function tweet(message, tokens) {
+    return callTwitterApi("POST", "https://api.twitter.com/1.1/statuses/update.json", {status: message}, tokens);
+}
+function searchTweets(str, tokens) {
+    return callTwitterApi("GET", "https://api.twitter.com/1.1/search/tweets.json", {q: str, count: 100}, tokens);
+}
+function readTimeline(id, tokens) {
+    return callTwitterApi("GET", "https://api.twitter.com/1.1/statuses/user_timeline.json", {user_id: id, count: 1000}, tokens);
+}
+function getMentions(tokens) {
+    return callTwitterApi("GET", "https://api.twitter.com/1.1/statuses/mentions_timeline.json", {count: 200}, tokens);
+}
+function getScreenName(id, tokens) {
+    return new Promise((resolve, reject) => {
+        let screenNameMap = JSON.parse(localStorage.getItem("screenNameMap"));
+        if (screenNameMap.hasOwnProperty(id) && new Date().getTime() - screenNameMap[id].lastModified < 3600000) {
+            resolve(screenNameMap[id].screenName);
+        } else {
+            callTwitterApi("GET", "https://api.twitter.com/1.1/users/show.json", {user_id: id}, tokens).then(user => {
+                screenNameMap = JSON.parse(localStorage.getItem("screenNameMap"));
+                screenNameMap[id] = {
+                    screenName: user["screen_name"],
+                    lastModified: new Date().getTime()
+                };
+                localStorage.setItem("screenNameMap", JSON.stringify(screenNameMap));
+                resolve(user["screen_name"]);
+            }).catch(() => {
+                resolve(screenNameMap.hasOwnProperty(id) ? screenNameMap[id].screenName : "???");
+            });
+        }
+    });
+}
+function getUserId(screenName, tokens) {
+    return callTwitterApi("GET", "https://api.twitter.com/1.1/users/show.json", {screen_name: screenName}, tokens).then(user => Promise.resolve(user["id"]));
 }
 
-function onRegisterNgSiteButtonClickHandler(info, currentTab) {
-    let urlList = JSON.parse(localStorage.getItem("urlList"));
-    let domain = (currentTab.url.split("/"))[2];
-    let index = urlList.findIndex(url => url == domain);
-    
-    if(info.menuItemId == "register_ngsite_button" && index ==-1){
-      urlList.push(domain);
-      localStorage.setItem("urlList", JSON.stringify(urlList));
-      var notification = new Notification(domain + "をNGサイトに登録しました");
-      setTimeout(notification.close.bind(notification),2000);
+// 1個以上の文字数が不明な文字列を用いて140文字以内のツイートを作る、という問題の解決を助ける関数
+function generateTweet(baseMessageGenerator) {
+    let elementHolders = Array.from(arguments).slice(1);
+    // RFC3986定義の厳密なHTTP URIの正規表現
+    // http://sinya8282.sakura.ne.jp/?p=1064
+    let uriPattern = /https?:(\/\/(([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=])*@)?(\[(([0-9a-f]{1,4}:){6}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|::([0-9a-f]{1,4}:){5}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|([0-9a-f]{1,4})?::([0-9a-f]{1,4}:){4}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:)?[0-9a-f]{1,4})?::([0-9a-f]{1,4}:){3}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::([0-9a-f]{1,4}:){2}([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::([0-9a-f]{1,4}:[0-9a-f]{1,4}|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]))|(([0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(([0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::|v[0-9a-f]+\.[!$&-.0-;=_a-z~]+)\]|(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d{2}|2[0-4]\d|25[0-5])|([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,;=])*)(:\d*)?(\/([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])*)*|\/(([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])+(\/([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])*)*)?|([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])+(\/([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,:;=@])*)*)?(\?([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,/:;=?@])*)?(#([-.0-9_a-z~]|%[0-9a-f][0-9a-f]|[!$&-,/:;=?@])*)?/ig;
+    // 自由に使える文字数 = 140 - ベースとなる文字列の文字数
+    // URIはt.coで短縮されて23文字になるので考慮しておく
+    let freeLength = 140 - baseMessageGenerator(...new Array(baseMessageGenerator.length).fill("")).replace(uriPattern, "x".repeat(23)).length;
+    // 各文字数が不明な文字列が使える文字数の上限を割り振る
+    // 自由に使える文字数が74文字で、文字数が不明な文字列が3個ならば、[25文字, 25文字, 24文字]のように割り振る
+    let upperLimitLengths = new Array(elementHolders.length).fill()
+        .map((_, i) => Math.floor(freeLength / elementHolders.length) + (i < freeLength % elementHolders.length ? 1 : 0));
+    return baseMessageGenerator(...elementHolders.map((elementHolder, i) => {
+        // 文字数が不明な文字列中の@#をエスケープしてリプライ誤爆やハッシュタグ誤爆を防ぐ
+        let element = elementHolder.element.replace(/([@#＠＃])/g, "$1\u200c");
+        return elementHolder.formatter(
+            element,
+            upperLimitLengths[i],
+            // elementの先頭を、使える文字数の上限だけ切り取り、さらに末尾cutLength文字切った文字列を返す関数
+            // 末尾を切った結果、末尾が@#になってしまうと、リプライ誤爆やハッシュタグ誤爆を起こしかねないので、その際は末尾の@#も切る
+            cutLength => element.substring(0, upperLimitLengths[i] - cutLength).replace(/[@#＠＃]$/, "")
+        );
+    }));
+}
+
+function notificate(message, displaySeconds) {
+    let notification = new Notification(message, {
+        icon: "images/ugenchan.png"
+    });
+    if (displaySeconds > 0) {
+        setTimeout(() => {
+            notification.close();
+        }, displaySeconds * 1000);
     }
-    if(info.menuItemId == "remove_ngsite_button" && index != -1){
-      urlList.splice(index, 1);
-      localStorage.setItem("urlList", JSON.stringify(urlList));
-      var notification = new Notification(domain + "をNGサイトから除外しました");
-      setTimeout(notification.close.bind(notification),2000);
-    }
+    let audio = new Audio();
+    audio.autoplay = true;
+    audio.src = "sounds/alert.wav";
+}
+
+function getCurrentTab() {
+    return new Promise((resolve, reject) => {
+        chrome.tabs.query({currentWindow: true, active: true}, tabs => {
+            if (tabs.length == 1) resolve(tabs[0]);
+            else reject(new Error("Could not find current window."));
+        });
+    });
+}
+
+function createRegisterNgSiteButton(){
+    chrome.contextMenus.create({
+        title: "現在のタブをNGサイトに登録",
+        type: "normal",
+        id: "register_ngsite_button"
+    });
+    chrome.contextMenus.create({
+        title: "現在のタブをNGサイトから除外",
+        type: "normal",
+        id: "remove_ngsite_button"
+    });
+    chrome.contextMenus.onClicked.addListener((info, currentTab) => {
+        let urlList = JSON.parse(localStorage.getItem("urlList"));
+        let domain = currentTab.url.split("/")[2];
+        let index = urlList.findIndex(url => url == domain);
+
+        if (info.menuItemId == "register_ngsite_button" && index == -1) {
+            urlList.push(domain);
+            localStorage.setItem("urlList", JSON.stringify(urlList));
+            notificate(`${domain}をNGサイトに登録しました`, 2);
+        }
+        if (info.menuItemId == "remove_ngsite_button" && index != -1) {
+            urlList.splice(index, 1);
+            localStorage.setItem("urlList", JSON.stringify(urlList));
+            notificate(`${domain}をNGサイトから除外しました`);
+        }
+    });
 }
 
 function onOAuthButtonClickHandler() {
-    let message = {
-        method: "POST",
-        action: "https://api.twitter.com/oauth/request_token",
-        parameters: {
-            oauth_callback: "oob"
-        }
-    };
-    OAuth.completeRequest(message, {
-        consumerKey: CONSUMER_KEY,
-        consumerSecret: CONSUMER_SECRET
-    });
-    $.ajax({
-        type: message.method,
-        url: message.action,
-        headers: {
-            "Authorization": OAuth.getAuthorizationHeader("", message.parameters)
-        },
-        dataType: "text",
-        success: responseText => {
-            chrome.tabs.query({currentWindow: true, active: true}, tabs => {
-                let currentTab = tabs[0];
-                let queryMap = OAuth.getParameterMap(responseText);
-                queryMap["window_id"] = currentTab.windowId.toString();
-                open(OAuth.addToURL("pin.html", queryMap), "", "width=300, height=100");
-            });
-        },
-        error: responseObject => {
-            alert(`Error: ${responseObject.status} ${responseObject.statusText}\n${responseObject.responseText}`);
-        }
-    });
+    getCurrentTab().then(currentTab =>
+        callTwitterApi("POST", "https://api.twitter.com/oauth/request_token", {oauth_callback: "oob"}, {}).then(queryMap => {
+            queryMap["window_id"] = currentTab.windowId.toString();
+            open(OAuth.addToURL("pin.html", queryMap), "", "width=300, height=100");
+        })
+    ).catch(e => { alert(e.message); })
 }
 
 function getLocalStorageData(key) {

--- a/chrome_extension/javascripts/config.js
+++ b/chrome_extension/javascripts/config.js
@@ -96,13 +96,17 @@ $(() => {
         $("#new_account_text").val("");
         $("#new_account_text").trigger("keydown");
         getUserId(screenName).then(userId => {
-            return tweet(`@${screenName} ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。`).then(status => {
-                let replySetting = JSON.parse(localStorage.getItem("replySetting"));
-                replySetting[localStorage.getItem("userId")].replyIdForPermissionMap[userId] = status["id"];
-                localStorage.setItem("replySetting", JSON.stringify(replySetting));
-                flushReplyAccounts();
-                notificate(`@${screenName}にリプライを送りました`, 2);
-            });
+            if (JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountIds.indexOf(userId) > -1) {
+                notificate(`@${screenName}からは既に許可を得ています`, 2);
+            } else {
+                return tweet(`@${screenName} ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。`).then(status => {
+                    let replySetting = JSON.parse(localStorage.getItem("replySetting"));
+                    replySetting[localStorage.getItem("userId")].replyIdForPermissionMap[userId] = status["id"];
+                    localStorage.setItem("replySetting", JSON.stringify(replySetting));
+                    flushReplyAccounts();
+                    notificate(`@${screenName}にリプライを送りました`, 2);
+                });
+            }
         }).catch(e => { alert(e.message); });
     });
 

--- a/chrome_extension/javascripts/config.js
+++ b/chrome_extension/javascripts/config.js
@@ -1,9 +1,5 @@
 "use strict";
 
-function flushReplyAccount() {
-    $("#account").text(`現在の宛先: ${localStorage.getItem("replyAccount")}`);
-}
-
 $(() => {
     function addRow(targetUrl) {
         let tr = $('<tr><td class="col-lg-4"></td><td><input type="button" value="×" class="btn btn-danger"></td></tr>');
@@ -27,11 +23,87 @@ $(() => {
         $("#add_url_text").val("http://");
     });
 
-    $("#modify_account_text").val(localStorage.getItem("replyAccount"));
+    function flushReplyAccount() {
+        let replyAccountId = JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountId;
+        (replyAccountId == -1 ? Promise.resolve("無し") : getScreenName(replyAccountId)).then(screenName => {
+            $("#account").text(`現在の宛先: ${screenName}`);
+        });
+    }
+    function flushReplyAccounts() {
+        let myReplySetting = JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")];
+        $("#modify_account_select").empty();
+        $("#modify_account_select").append($('<option value="-1">無し</option>'));
+        Promise.all([].concat(
+            myReplySetting.replyAccountIds.map(replyAccountId =>
+                getScreenName(replyAccountId).then(screenName =>
+                    Promise.resolve($(document.createElement("option")).attr("value", replyAccountId).text(screenName))
+                )
+            ),
+            Object.keys(myReplySetting.replyIdForPermissionMap).map(replyAccountId =>
+                getScreenName(replyAccountId).then(screenName =>
+                    Promise.resolve($(document.createElement("option")).attr("value", replyAccountId).prop("disabled", true).text(`${screenName}（許可待ち）`))
+                )
+            )
+        )).then(options => {
+            options.sort((x, y) => x.text() < y.text() ? 1 : -1);
+            for (let option of options) {
+                $("#modify_account_select").append(option);
+            }
+            $("#modify_account_select").val(myReplySetting.replyAccountId);
+        });
+    }
     flushReplyAccount();
+    getMentions().then(statuses => {
+        let replySetting = JSON.parse(localStorage.getItem("replySetting"));
+        let myReplySetting = replySetting[localStorage.getItem("userId")];
+
+        let replyIdToUserId = {};
+        for (let userId of Object.keys(myReplySetting.replyIdForPermissionMap).map(str => parseInt(str, 10))) {
+            let replyId = myReplySetting.replyIdForPermissionMap[userId];
+            replyIdToUserId[replyId] = userId;
+        }
+
+        for (let status of statuses) {
+            if (replyIdToUserId.hasOwnProperty(status["in_reply_to_status_id"]) && replyIdToUserId[status["in_reply_to_status_id"]] == status["user"]["id"]) {
+                let userId = replyIdToUserId[status["in_reply_to_status_id"]];
+                delete myReplySetting.replyIdForPermissionMap[userId];
+                myReplySetting.replyAccountIds.push(userId);
+                getScreenName(userId).then(screenName => {
+                    notificate(`@${screenName}からリプライの許可が下りました`, 2);
+                });
+            }
+        }
+
+        localStorage.setItem("replySetting", JSON.stringify(replySetting));
+    }).catch(() => Promise.resolve()).then(flushReplyAccounts);
     $("#modify_account_button").click(() => {
-        localStorage.setItem("replyAccount", $("#modify_account_text").val());
+        let replySetting = JSON.parse(localStorage.getItem("replySetting"));
+        replySetting[localStorage.getItem("userId")].replyAccountId = parseInt($("#modify_account_select").val(), 10);
+        localStorage.setItem("replySetting", JSON.stringify(replySetting));
         flushReplyAccount();
+    });
+
+    $("#new_account_text").on("keydown", () => {
+        setTimeout(() => {
+            $("#new_account_button").prop("disabled", $("#new_account_text").val() == "");
+            $("#permission_message_destination").text($("#new_account_text").val());
+            $("#permission_message").text(`@${$("#new_account_text").val()} ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。`);
+        }, 0);
+    });
+    $("#new_account_text").trigger("keydown");
+    $("#new_account_button").click(() => {
+        let screenName = $("#new_account_text").val();
+        $("#new_account_text").val("");
+        $("#new_account_text").trigger("keydown");
+        getUserId(screenName).then(userId => {
+            return tweet(`@${screenName} ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。`).then(status => {
+                let replySetting = JSON.parse(localStorage.getItem("replySetting"));
+                replySetting[localStorage.getItem("userId")].replyIdForPermissionMap[userId] = status["id"];
+                localStorage.setItem("replySetting", JSON.stringify(replySetting));
+                flushReplyAccounts();
+                notificate(`@${screenName}にリプライを送りました`, 2);
+            });
+        }).catch(e => { alert(e.message); });
     });
 
     $("#oauth_button").click(onOAuthButtonClickHandler);

--- a/chrome_extension/javascripts/consumer_key_and_secret.js
+++ b/chrome_extension/javascripts/consumer_key_and_secret.js
@@ -1,4 +1,0 @@
-"use strict";
-
-var CONSUMER_KEY = "mqnjswbYNsvfnwp8N3aoPs5TU";
-var CONSUMER_SECRET = "dbaio9YDq5S1X3cL5AceWbFgsaADOaA9B8TrRU2TnDLlYZTVLP";

--- a/chrome_extension/javascripts/mocking.js
+++ b/chrome_extension/javascripts/mocking.js
@@ -6,13 +6,11 @@ if (location.protocol != "chrome-extension:") {
         close() {}
     });
     window.close = () => {};
-    window.Notification = function () {};
-    window.Notification.prototype.close = () => {};
     window.chrome = {
         browserAction: {
             setBadgeText() {},
             setBadgeBackgroundColor() {},
-            setIcon() {},
+            setIcon() {}
         },
         contextMenus: {
             create() {},
@@ -26,24 +24,32 @@ if (location.protocol != "chrome-extension:") {
                         for (let listener of listeners) {
                             listener(info, tab);
                         }
-                    },
+                    }
                 };
-            }(),
+            }()
         },
         extension: {},
         tabs: {
             update() {},
-            create() {},
-            query(parameter, callback) {
-                callback([{
-                    id: 0,
-                    windowId: 0,
-                    url: "http://example.com/",
-                    title: "Example",
-                }]);
-            },
-        },
+            create() {}
+        }
     };
+    window.getMentions = () => Promise.resolve([]);
+    window.getScreenName = userId => Promise.resolve({
+        "3315564288": "UGEN_bot",
+        "3356282660": "UGEN_teacher"
+    }[userId]);
+    window.getUserId = screenName => Promise.resolve({
+        "UGEN_bot": 3315564288,
+        "UGEN_teacher": 3356282660
+    }[screenName]);
+    window.notificate = () => {};
+    window.getCurrentTab = () => Promise.resolve({
+        id: 0,
+        windowId: 0,
+        url: "http://example.com/",
+        title: "Example"
+    });
     () => {
         let original$ = window.$;
         let onloadFuncs = [];

--- a/chrome_extension/javascripts/pin.js
+++ b/chrome_extension/javascripts/pin.js
@@ -1,49 +1,41 @@
 "use strict";
 
-let queryMap = OAuth.getParameterMap(location.search.replace(/\?/, ""));
-chrome.tabs.create({
-    windowId: parseInt(queryMap["window_id"], 10),
-    url: OAuth.addToURL("http://twitter.com/oauth/authorize", {
-        oauth_token: queryMap["oauth_token"]
-    })
-});
-
 $(() => {
+    let queryMap = OAuth.getParameterMap(location.search.replace(/\?/, ""));
+    chrome.tabs.create({
+        windowId: parseInt(queryMap["window_id"], 10),
+        url: OAuth.addToURL("http://twitter.com/oauth/authorize", {
+            oauth_token: queryMap["oauth_token"]
+        })
+    });
+
     $("#pin_button").click(() => {
-        let message = {
-            method: "POST",
-            action: "https://api.twitter.com/oauth/access_token",
-            parameters: {
-                oauth_verifier: $("#pin_text").val()
-            }
-        };
-        OAuth.completeRequest(message, {
-            consumerKey: CONSUMER_KEY,
-            consumerSecret: CONSUMER_SECRET,
+        callTwitterApi("POST", "https://api.twitter.com/oauth/access_token", {
+            oauth_verifier: $("#pin_text").val()
+        }, {
             token: queryMap["oauth_token"],
             tokenSecret: queryMap["oauth_token_secret"]
-        });
-        $.ajax({
-            type: message.method,
-            url: message.action,
-            headers: {
-                "Authorization": OAuth.getAuthorizationHeader("", message.parameters)
-            },
-            dataType: "text",
-            success: responseText => {
-                let accessTokenMap = OAuth.getParameterMap(responseText);
-                localStorage.setItem("accessToken", accessTokenMap["oauth_token"]);
-                localStorage.setItem("accessTokenSecret", accessTokenMap["oauth_token_secret"]);
-                localStorage.setItem("userId", accessTokenMap["user_id"]);
-                $("body > p").text("Twitter連携の設定が完了しました。");
-                setTimeout(close, 2000);
-            },
-            error: responseObject => {
-                $("body > p").empty()
-                    .append(document.createTextNode(`Error: ${responseObject.status} ${responseObject.statusText}`))
-                    .append(document.createElement("br"))
-                    .append(document.createTextNode(responseObject.responseText));
+        }).then(accessTokenMap => {
+            localStorage.setItem("accessToken", accessTokenMap["oauth_token"]);
+            localStorage.setItem("accessTokenSecret", accessTokenMap["oauth_token_secret"]);
+            localStorage.setItem("userId", accessTokenMap["user_id"]);
+            let replySetting = JSON.parse(localStorage.getItem("replySetting"));
+            if (!replySetting.hasOwnProperty(accessTokenMap["user_id"])) {
+                replySetting[accessTokenMap["user_id"]] = {
+                    replyAccountId: -1,
+                    replyAccountIds: [],
+                    replyIdForPermissionMap: {}
+                };
+                localStorage.setItem("replySetting", JSON.stringify(replySetting));
             }
+            $("body > p").text("Twitter連携の設定が完了しました。");
+            setTimeout(close, 2000);
+        }).catch(e => {
+            $("body > p").empty();
+            e.message.split(/\n/g).forEach(line => {
+                $("body > p").append(document.createTextNode(line));
+                $("body > p").append(document.createElement("br"));
+            });
         });
     });
 });

--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -17,7 +17,7 @@ $(() => {
             on: "監視中",
         }[bg.timerState]);
         
-        if(!getLocalStorageData("accessToken") || !getLocalStorageData("accessTokenSecret")) {
+        if(getLocalStorageData("userId") === null) {
             $("#guide_message").text("Twitter連携をしてね！");
             $("#start_control").css("display", "none");
             $("#oauth_control").css("display", "block");
@@ -57,7 +57,7 @@ $(() => {
         refreshPageContent();
     });
     $("#end_button").click(() => {
-        bg.tweet(bg.generateTweet(
+        bg.tweet(generateTweet(
             element => `${Math.round(bg.limitSeconds / 60)}分かかると見積もった${element}を${Math.round(bg.elapsedSeconds / 60)}分で終えました! ${new Date()} #UGEN`,
             {
                 element: bg.taskDescription,
@@ -65,9 +65,9 @@ $(() => {
                     if (element == "") return "作業";
                     if (element.length + 2 <= upperLimitLength) return `「${element}」`;
                     return `「${getShortenedString(5)}...」`;
-                },
+                }
             }
-        ), () => { bg.alert("tweetしたよ^_^"); });
+        )).then(() => { bg.alert("tweetしたよ^_^"); }).catch(e => { bg.alert(e.message); });
         bg.notifyRank();
         bg.stopTimer();
         refreshPageContent();

--- a/chrome_extension/pin.html
+++ b/chrome_extension/pin.html
@@ -6,10 +6,9 @@
 <script type="text/javascript" src="lib/jquery-1.11.3.min.js"></script>
 <script type="text/javascript" src="lib/sha1.js"></script>
 <script type="text/javascript" src="lib/oauth.js"></script>
+<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/mocking.js"></script>
-<script type="text/javascript" src="javascripts/consumer_key_and_secret.js"></script>
 <script type="text/javascript" src="javascripts/pin.js"></script>
-<link rel="stylesheet" href="style.css" type="text/css">
 </head>
 <body>
     <p>

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -7,9 +7,8 @@
 <script type="text/javascript" src="lib/bootstrap/bootstrap.min.js"></script>
 <script type="text/javascript" src="lib/sha1.js"></script>
 <script type="text/javascript" src="lib/oauth.js"></script>
-<script type="text/javascript" src="javascripts/mocking.js"></script>
-<script type="text/javascript" src="javascripts/consumer_key_and_secret.js"></script>
 <script type="text/javascript" src="javascripts/common.js"></script>
+<script type="text/javascript" src="javascripts/mocking.js"></script>
 <script type="text/javascript" src="javascripts/popup.js"></script>
 <link rel="stylesheet" href="lib/bootstrap/bootstrap.min.css" type="text/css">
 <link rel="stylesheet" href="popup.css" type="text/css">

--- a/chrome_extension/spec/javascripts/basic_spec.js
+++ b/chrome_extension/spec/javascripts/basic_spec.js
@@ -10,6 +10,14 @@ describe("基本機能", () => {
     beforeEach(done => {
         let prefix = location.protocol == "http:" ? "base/" : "";
         localStorage.clear();
+        localStorage.setItem("userId", "3315564288");
+        localStorage.setItem("replySetting", JSON.stringify({
+            "3315564288": {
+                replyAccountId: -1,
+                replyAccountIds: [],
+                replyIdForPermissionMap: {}
+            }
+        }));
         jasmine.getFixtures().fixturesPath = `${prefix}spec/javascripts/fixtures`;
         loadFixtures("fixture.html");
         $("#background").load(() => {
@@ -23,24 +31,26 @@ describe("基本機能", () => {
         });
         $("#background").attr("src", `${prefix}background.html`);
     });
-    it("タスクを見積もり時間内に終わらせると見積もり時間と実際にかかった時間をツイートする", done => {
+    it("タスクが見積もり時間内に終わったとき見積もり時間と実際にかかった時間をツイートする", done => {
         setMock(background, {
             tweet(message) {
                 expect(message).toContain("1分かかると見積もった作業を0分で終えました");
-                done();
-            },
+                setTimeout(done, 0);
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("1");
         popup.$("#start_button").click();
         popup.$("#end_button").click();
     });
-    it("タスクが見積もり時間内に終わらないと謝罪ツイートをする", done => {
+    it("タスクが見積もり時間内に終わらなかったときツイートする", done => {
         setMock(background, {
             tweet(message) {
-                expect(message).toContain("申し訳ありません");
-                done();
-            },
+                expect(message).toContain("私は作業時間の見積もりに失敗しました");
+                setTimeout(done, 0);
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("0");
@@ -48,26 +58,17 @@ describe("基本機能", () => {
     });
     it("ブロックサイトを一定時間閲覧し続けていると警告を表示する", done => {
         setMock(background, {
-            setTimeout: (originalSetTimeout => {
-                return (func, ms) => originalSetTimeout(func, 0);
-            })(background.setTimeout),
-            chrome: {
-                tabs: {
-                    query(parameter, callback) {
-                        callback([{
-                            id: 0,
-                            windowId: 0,
-                            url: "http://www.nicovideo.jp/",
-                            title: "niconico",
-                        }]);
-                    },
-                },
-            },
-            Notification: function (message) {
-                this.close = () => {};
+            wait: 10,
+            getCurrentTab: () => Promise.resolve({
+                id: 0,
+                windowId: 0,
+                url: "http://www.nicovideo.jp/",
+                title: "niconico"
+            }),
+            notificate(message) {
                 expect(message).toContain("あと 5 秒 niconico に滞在すると");
-                done();
-            },
+                setTimeout(done, 0);
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("2");
@@ -77,43 +78,41 @@ describe("基本機能", () => {
         let count = 2;
         function partiallyDone() {
             count--;
-            if (count == 0) done();
+            if (count == 0) setTimeout(done, 0);
         }
         setMock(background, {
-            setTimeout: (originalSetTimeout => {
-                return (func, ms) => originalSetTimeout(func, 0);
-            })(background.setTimeout),
+            wait: 10,
+            getCurrentTab: () => Promise.resolve({
+                id: 0,
+                windowId: 0,
+                url: "http://www.nicovideo.jp/",
+                title: "niconico"
+            }),
             chrome: {
                 tabs: {
-                    query(parameter, callback) {
-                        callback([{
-                            id: 0,
-                            windowId: 0,
-                            url: "http://www.nicovideo.jp/",
-                            title: "niconico",
-                        }]);
-                    },
                     update(id, parameter) {
                         expect(parameter.url).toEqual("chrome://newtab/");
                         partiallyDone();
-                    },
-                },
+                    }
+                }
             },
             tweet(message) {
                 expect(message).toContain("作業をサボっていました");
                 partiallyDone();
-            },
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
-        popup.$("#task_time_text").val("1");
+        popup.$("#task_time_text").val("2");
         popup.$("#start_button").click();
     });
     it("作業内容を入力してタスクが見積もり時間内に終わったとき作業内容をツイートする", done => {
         setMock(background, {
             tweet(message) {
                 expect(message).toContain("動作確認作業");
-                done();
-            },
+                setTimeout(done, 0);
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
         // setTimeoutを使う理由: blur()の直後にfocus()は効かない
@@ -131,8 +130,9 @@ describe("基本機能", () => {
         setMock(background, {
             tweet(message) {
                 expect(message).toContain("動作確認作業");
-                done();
-            },
+                setTimeout(done, 0);
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
         setTimeout(() => {
@@ -145,29 +145,22 @@ describe("基本機能", () => {
     });
     it("作業内容を入力してブロックサイトを閲覧し続けていたとき作業内容をツイートする", done => {
         setMock(background, {
-            setTimeout: (originalSetTimeout => {
-                return (func, ms) => originalSetTimeout(func, 0);
-            })(background.setTimeout),
-            chrome: {
-                tabs: {
-                    query(parameter, callback) {
-                        callback([{
-                            id: 0,
-                            windowId: 0,
-                            url: "http://www.nicovideo.jp/",
-                            title: "niconico",
-                        }]);
-                    },
-                },
-            },
+            wait: 10,
+            getCurrentTab: () => Promise.resolve({
+                id: 0,
+                windowId: 0,
+                url: "http://www.nicovideo.jp/",
+                title: "niconico"
+            }),
             tweet(message) {
                 expect(message).toContain("動作確認作業");
-                done();
-            },
+                setTimeout(done, 0);
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
         setTimeout(() => {
-            popup.$("#task_time_text").val("1");
+            popup.$("#task_time_text").val("2");
             popup.$("#task_description_text").focus();
             popup.$("#task_description_text").val("動作確認作業");
             popup.$("#task_description_text").blur();
@@ -178,7 +171,7 @@ describe("基本機能", () => {
         let count = 2;
         function partiallyDone() {
             count--;
-            if (count == 0) done();
+            if (count == 0) setTimeout(done, 0);
         }
         setMock(background, {
             chrome: {
@@ -190,9 +183,9 @@ describe("基本機能", () => {
                     setBadgeBackgroundColor(parameter) {
                         expect(parameter.color).toEqual([0, 0, 255, 100]);
                         partiallyDone();
-                    },
-                },
-            },
+                    }
+                }
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("2");
@@ -202,7 +195,7 @@ describe("基本機能", () => {
         let count = 2;
         function partiallyDone() {
             count--;
-            if (count == 0) done();
+            if (count == 0) setTimeout(done, 0);
         }
         setMock(background, {
             chrome: {
@@ -214,9 +207,9 @@ describe("基本機能", () => {
                     setBadgeBackgroundColor(parameter) {
                         expect(parameter.color).toEqual([255, 0, 0, 100]);
                         partiallyDone();
-                    },
-                },
-            },
+                    }
+                }
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("1");
@@ -224,11 +217,10 @@ describe("基本機能", () => {
     });
     it("タスク終了予定時刻まで残り1分以下になった瞬間、警告を表示する", done => {
         setMock(background, {
-            Notification: function (message) {
-                this.close = () => {};
+            notificate(message) {
                 expect(message).toContain("あと1分でtweetされます");
-                done();
-            },
+                setTimeout(done, 0);
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("1");
@@ -249,44 +241,39 @@ describe("基本機能", () => {
     it("監視停止中はブロックサイトを閲覧してもサボり通知ツイートがされたり「新しいタブ」ページへ飛ばされたりしない", done => {
         let isDone = false;
         setMock(background, {
-            setTimeout: (originalSetTimeout => {
-                return (func, ms) => originalSetTimeout(func, 0);
-            })(background.setTimeout),
+            wait: 10,
+            getCurrentTab: () => background.timerState == "pause"
+                ? Promise.resolve({
+                    id: 0,
+                    windowId: 0,
+                    url: "http://www.nicovideo.jp/",
+                    title: "niconico"
+                })
+                : Promise.resolve({
+                    id: 0,
+                    windowId: 0,
+                    url: "http://example.com/",
+                    title: "Example"
+                }),
             chrome: {
                 tabs: {
-                    query(parameter, callback) {
-                        if (background.timerState == "pause") {
-                            callback([{
-                                id: 0,
-                                windowId: 0,
-                                url: "http://www.nicovideo.jp/",
-                                title: "niconico",
-                            }]);
-                        } else {
-                            callback([{
-                                id: 0,
-                                windowId: 0,
-                                url: "http://example.com/",
-                                title: "Example",
-                            }]);
-                        }
-                    },
                     update(id, parameter) {
                         if (!isDone) {
                             fail("chrome.tabs.update()が呼ばれた");
                             isDone = true;
-                            done();
+                            setTimeout(done, 0);
                         }
-                    },
-                },
+                    }
+                }
             },
             tweet(message) {
                 if (!isDone) {
                     fail("tweet()が呼ばれた");
                     isDone = true;
-                    done();
+                    setTimeout(done, 0);
                 }
-            },
+                return Promise.resolve();
+            }
         });
         setMock(popup, {});
         popup.$("#task_time_text").val("100");
@@ -296,7 +283,7 @@ describe("基本機能", () => {
             if (!isDone) {
                 expect(true).toBe(true);
                 isDone = true;
-                done();
+                setTimeout(done, 0);
             }
         }, 500);
     });

--- a/chrome_extension/spec/javascripts/function_spec.js
+++ b/chrome_extension/spec/javascripts/function_spec.js
@@ -25,7 +25,7 @@ describe("関数の入出力", () => {
                     element: "x".repeat(140),
                     formatter(element, upperLimitLength, getShortenedString) {
                         return `${getShortenedString(5)}.....`;
-                    },
+                    }
                 }
             );
             expect(tweet).toEqual(`${"x".repeat(130)}.....yyyyy`);
@@ -37,13 +37,13 @@ describe("関数の入出力", () => {
                     element: "x".repeat(140),
                     formatter(element, upperLimitLength, getShortenedString) {
                         return `${getShortenedString(5)}.....`;
-                    },
+                    }
                 },
                 {
                     element: "z".repeat(140),
                     formatter(element, upperLimitLength, getShortenedString) {
                         return `${getShortenedString(5)}.....`;
-                    },
+                    }
                 }
             );
             expect(tweet).toEqual(`${"x".repeat(63)}.....yyyyy${"z".repeat(62)}.....`);
@@ -55,7 +55,7 @@ describe("関数の入出力", () => {
                     element: "x".repeat(140),
                     formatter(element, upperLimitLength, getShortenedString) {
                         return getShortenedString(0);
-                    },
+                    }
                 }
             );
             expect(tweet.split("|")[0]).toEqual("x".repeat(140 - 23 * 2 - 2));
@@ -67,7 +67,7 @@ describe("関数の入出力", () => {
                     element: "@tos",
                     formatter(element, upperLimitLength, getShortenedString) {
                         return element;
-                    },
+                    }
                 }
             );
             expect(tweet).toEqual("@\u200ctos");
@@ -79,7 +79,7 @@ describe("関数の入出力", () => {
                     element: `${"x".repeat(130)}@tos`,
                     formatter(element, upperLimitLength, getShortenedString) {
                         return getShortenedString(0);
-                    },
+                    }
                 }
             );
             expect(tweet).toEqual(`${"x".repeat(130)}TwitterJP`);


### PR DESCRIPTION
- [x] タスク失敗リプライの相手に対して、「リプライ先にしてもいいですか？」の許可リプライを飛ばす
- [x] タスク失敗リプライ先申請に対し、リプライが返ってきたことを感知し（リプライidとリプライ返しidを紐付ける）、感知した後はタスク失敗リプライ相手に設定できるようにする
- [x] タスク失敗リプライ相手を設定していない場合は、タスク失敗リプライをただのツイートにする
- [x] タスク失敗リプライ相手へ申請を出していて許可がもらえていない状態・許可が出ている状態を設定画面で表示する
- [x] テストを書く
- [x] テストを通す