### PR TITLE
テスト用の環境構築に失敗するバグの修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
     - 4.2
 before_install:
-    - sudo apt-get install --assume-yes libxss1 fonts-liberation libappindicator1
+    - sudo apt-get update
+    - sudo apt-get install --assume-yes fonts-liberation libappindicator1
     - wget -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
     - sudo dpkg -i /tmp/chrome.deb
     - export CHROME_BIN=google-chrome-stable


### PR DESCRIPTION
よく分かりませんがUbuntuの更新か何かのせい？でテスト用の環境構築のところで必ず失敗するようになっていたので修正しました