### PR TITLE
タブの内容をツイートする機能の「非推奨」の記述を消した

### DIFF
--- a/chrome_extension/config.html
+++ b/chrome_extension/config.html
@@ -55,7 +55,7 @@
         <h2 class="sub-header">追加機能</h2>
         <div class="well">
             <p>
-            <input type="checkbox" id="tweet_tabinfo_checkbox">サボり通知ツイートにタブの情報を含める(非推奨)
+            <input type="checkbox" id="tweet_tabinfo_checkbox">サボり通知ツイートにタブの情報を含める
             </p>
             <input type="checkbox" id="show_register_ngsite_button_checkbox">コンテキストメニューにNGサイト登録機能を表示する
         </div>


### PR DESCRIPTION
非推奨だったらじゃあ実装するなよという感じを受けるので、非推奨という文字は消してしまうか、そうでなければ非推奨以外の表現を使いたい