### PR TITLE
TWEET_PHRASESを改良

### DIFF
--- a/chrome_extension/config.html
+++ b/chrome_extension/config.html
@@ -7,6 +7,8 @@
 <script type="text/javascript" src="lib/bootstrap/bootstrap.min.js"></script>
 <script type="text/javascript" src="lib/sha1.js"></script>
 <script type="text/javascript" src="lib/oauth.js"></script>
+<script type="text/javascript" src="lib/sprintf.min.js"></script>
+<script type="text/javascript" src="javascripts/tweet_phrases.js"></script>
 <script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/mocking.js"></script>
 <script type="text/javascript" src="javascripts/config.js"></script>
@@ -55,7 +57,7 @@
         <h2 class="sub-header">追加機能</h2>
         <div class="well">
             <p>
-            <input type="checkbox" id="tweet_tabinfo_checkbox">サボり通知ツイートにタブの情報を含める(非推奨)
+            <input type="checkbox" id="tweet_tab_info_checkbox">サボり通知ツイートにタブの情報を含める(非推奨)
             </p>
             <input type="checkbox" id="show_register_ngsite_button_checkbox">コンテキストメニューにNGサイト登録機能を表示する
         </div>

--- a/chrome_extension/javascripts/background.js
+++ b/chrome_extension/javascripts/background.js
@@ -35,27 +35,29 @@ function mainLoop() {
 
         let replyAccountId = JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountId;
         if (replyAccountId == -1) {
+            let now = new Date();
             tweet(generateTweet(
-                element => `私は${element}作業時間の見積もりに失敗しました ${new Date()} #UGEN`,
+                element => sprintf(TWEET_PHRASES.FAILED.WITHOUT_RECIPIENT, {taskDescription: element, date: now}),
                 {
                     element: taskDescription,
                     formatter(element, upperLimitLength, getShortenedString) {
-                        if (element == "") return "";
-                        if (element.length + 3 <= upperLimitLength) return `「${element}」の`;
-                        return `「${getShortenedString(6)}...」の`;
+                        if (element == "") return "作業";
+                        if (element.length + 5 <= upperLimitLength) return `「${element}」の作業`;
+                        return `「${getShortenedString(8)}...」の作業`;
                     }
                 }
             )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });
         } else {
             getScreenName(replyAccountId).then(screenName => {
+                let now = new Date();
                 tweet(generateTweet(
-                    element => sprintf(TWEET_PHRASES.FAILED, screenName, element, new Date()),
+                    element => sprintf(TWEET_PHRASES.FAILED.WITH_RECIPIENT, {recipient: screenName, taskDescription: element, date: now}),
                     {
                         element: taskDescription,
                         formatter(element, upperLimitLength, getShortenedString) {
-                            if (element == "") return "";
-                            if (element.length + 3 <= upperLimitLength) return `「${element}」の`;
-                            return `「${getShortenedString(6)}...」の`;
+                            if (element == "") return "作業";
+                            if (element.length + 5 <= upperLimitLength) return `「${element}」の作業`;
+                            return `「${getShortenedString(8)}...」の作業`;
                         }
                     }
                 )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });
@@ -74,9 +76,10 @@ function mainLoop() {
             notificate(`あと ${TWEET_TIME - ALERT_TIME} 秒 ${currentTab.title} に滞在するとTwitterに報告されます`, 2);
             break;
         case TWEET_TIME:
-            if(localStorage.getItem("tweetTabinfo") === "True") {
+            if(localStorage.getItem("tweetTabInfo") === "True") {
+                let now = new Date();
                 tweet(generateTweet(
-                    (element1, element2) => sprintf(TWEET_PHRASES.WATCHED_NGSITES.WITH_TABINFO, element1, element2, currentTab.url, new Date()),
+                    (element1, element2) => sprintf(TWEET_PHRASES.WATCHED_NG_SITES.WITH_TAB_INFO, {taskDescription: element1, siteName: element2, siteUrl: currentTab.url, date: now}),
                     {
                         element: taskDescription,
                         formatter(element, upperLimitLength, getShortenedString) {
@@ -94,8 +97,9 @@ function mainLoop() {
                     }
                 )).then(() => { alert("tweetしたよ^_^"); }).catch(e => { alert(e.message); });;
             } else {
+                let now = new Date();
                 tweet(generateTweet(
-                    element => sprintf(TWEET_PHRASES.WATCHED_NGSITES.WITHOUT_TABINFO, element, new Date()),
+                    element => sprintf(TWEET_PHRASES.WATCHED_NG_SITES.WITHOUT_TAB_INFO, {taskDescription: element, date: now}),
                     {
                         element: taskDescription,
                         formatter(element, upperLimitLength, getShortenedString) {

--- a/chrome_extension/javascripts/config.js
+++ b/chrome_extension/javascripts/config.js
@@ -87,7 +87,7 @@ $(() => {
         setTimeout(() => {
             $("#new_account_button").prop("disabled", $("#new_account_text").val() == "");
             $("#permission_message_destination").text($("#new_account_text").val());
-            $("#permission_message").text(`@${$("#new_account_text").val()} ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。`);
+            $("#permission_message").text(sprintf(TWEET_PHRASES.GET_PERMISSION, {recipient: $("#new_account_text").val()}));
         }, 0);
     });
     $("#new_account_text").trigger("keydown");
@@ -99,7 +99,7 @@ $(() => {
             if (JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountIds.indexOf(userId) > -1) {
                 notificate(`@${screenName}からは既に許可を得ています`, 2);
             } else {
-                return tweet(`@${screenName} ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。`).then(status => {
+                return tweet(sprintf(TWEET_PHRASES.GET_PERMISSION, {recipient: screenName})).then(status => {
                     let replySetting = JSON.parse(localStorage.getItem("replySetting"));
                     replySetting[localStorage.getItem("userId")].replyIdForPermissionMap[userId] = status["id"];
                     localStorage.setItem("replySetting", JSON.stringify(replySetting));
@@ -112,15 +112,15 @@ $(() => {
 
     $("#oauth_button").click(onOAuthButtonClickHandler);
 
-    $("#tweet_tabinfo_checkbox").change(function () {
+    $("#tweet_tab_info_checkbox").change(function () {
         if ($(this).is(":checked")) {
-            localStorage.setItem("tweetTabinfo", "True");
+            localStorage.setItem("tweetTabInfo", "True");
         } else {
-            localStorage.setItem("tweetTabinfo", "False");
+            localStorage.setItem("tweetTabInfo", "False");
         }
     });
-    if (localStorage.getItem("tweetTabinfo") === "True") {
-        $("#tweet_tabinfo_checkbox").prop("checked", true);
+    if (localStorage.getItem("tweetTabInfo") === "True") {
+        $("#tweet_tab_info_checkbox").prop("checked", true);
     }
     
     $("#show_register_ngsite_button_checkbox").change(function () {

--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -66,8 +66,9 @@ $(() => {
         refreshPageContent();
     });
     $("#end_button").click(() => {
+        let now = new Date();
         bg.tweet(bg.generateTweet(
-            element => sprintf(TWEET_PHRASES.SUCCESSED, Math.round(bg.limitSeconds / 60), element, Math.round(bg.elapsedSeconds / 60), new Date()),
+            element => sprintf(TWEET_PHRASES.SUCCESSED, {taskDescription: element, estimatedMinutes: Math.round(bg.limitSeconds / 60), actualMinutes: Math.round(bg.elapsedSeconds / 60), date: now}),
             {
                 element: bg.taskDescription,
                 formatter(element, upperLimitLength, getShortenedString) {

--- a/chrome_extension/javascripts/tweet_phrases.js
+++ b/chrome_extension/javascripts/tweet_phrases.js
@@ -1,8 +1,12 @@
 const TWEET_PHRASES = {
-    "WATCHED_NGSITES": {
-        "WITH_TABINFO":     "私は%sをサボって %s( %s ) を見ていました %s #UGEN",
-        "WITHOUT_TABINFO":  "私は%sをサボっていました %s #UGEN"
+    "WATCHED_NG_SITES": {
+        "WITH_TAB_INFO":     "私は%(taskDescription)sをサボって %(siteName)s( %(siteUrl)s ) を見ていました %(date)s #UGEN",
+        "WITHOUT_TAB_INFO":  "私は%(taskDescription)sをサボっていました %(date)s #UGEN"
     },
-    "FAILED":       "@%s 突然のリプライ失礼致します。このたび私事ながら作業時間の見積もりに失敗しました。誠に申し訳ありません %s #UGEN",
-    "SUCCESSED":    "%d分かかると見積もった%sを%d分で終えました! #UGEN %s"
+    "FAILED": {
+        "WITH_RECIPIENT":       "@%(recipient)s 突然のリプライ失礼致します。このたび私事ながら%(taskDescription)s時間の見積もりに失敗しました。誠に申し訳ありません %(date)s #UGEN",
+        "WITHOUT_RECIPIENT":    "私は%(taskDescription)s時間の見積もりに失敗しました %(date)s #UGEN"
+    },
+    "SUCCESSED":        "%(estimatedMinutes)d分かかると見積もった%(taskDescription)sを%(actualMinutes)d分で終えました! %(date)s #UGEN",
+    "GET_PERMISSION":   "@%(recipient)s ツールによる自動メッセージです。作業が見積もり時間内に終わらなかった時にリプライを自動で送るツールを使うことで作業の強制力を上げようとしています。リプライを送られることを許可する場合はこのリプライに返信してください。"
 };

--- a/chrome_extension/spec/javascripts/advanced_spec.js
+++ b/chrome_extension/spec/javascripts/advanced_spec.js
@@ -138,7 +138,7 @@ describe("詳細設定から設定できる機能", () => {
         });
         setMock(popup, {});
         setMock(config, {});
-        config.$("#tweet_tabinfo_checkbox").click();
+        config.$("#tweet_tab_info_checkbox").click();
         popup.$("#task_time_text").val("1");
         popup.$("#start_button").click();
     });


### PR DESCRIPTION
- 例えば `TWEET = "@%s %s"; sprintf(TWEET, "UGEN_teacher", new Date())` のような記法を `TWEET = "@%(recipient)s %(date)s"; sprintf(TWEET, {recipient: "UGEN_teacher", date: new Date()})` のような記法に変更することで、ツイートメッセージの定義と利用をより分離
- リプライ相手を設定していないときのタスク失敗時ツイートのメッセージと、リプライ許可申請ツイートのメッセージをTWEET_PHRASESに追加
- 単語の切れ目に_が入っていなかったNGSITESをNG_SITESに、TABINFOをTAB_INFOにそれぞれ変更