### PR TITLE
localStorageへのデータの保存形式を変更

### DIFF
--- a/chrome_extension/background.html
+++ b/chrome_extension/background.html
@@ -8,8 +8,8 @@
 <script type="text/javascript" src="lib/oauth.js"></script>
 <script type="text/javascript" src="lib/sprintf.min.js"></script>
 <script type="text/javascript" src="javascripts/tweet_phrases.js"></script>
-<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/mocking.js"></script>
+<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/background.js"></script>
 </head>
 <body>

--- a/chrome_extension/config.html
+++ b/chrome_extension/config.html
@@ -9,8 +9,8 @@
 <script type="text/javascript" src="lib/oauth.js"></script>
 <script type="text/javascript" src="lib/sprintf.min.js"></script>
 <script type="text/javascript" src="javascripts/tweet_phrases.js"></script>
-<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/mocking.js"></script>
+<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/config.js"></script>
 <link rel="stylesheet" href="lib/bootstrap/bootstrap.min.css" type="text/css">
 </head>
@@ -28,26 +28,26 @@
         </div>
         <h2 class="sub-header">タスク失敗時にリプライを送る相手</h2>
         <div class="well">
-            <p id="account">
+            <p id="current_recipient">
             </p>
             <form class="form-inline">
                 <div class="input-group">
                     <span class="input-group-addon">@</span>
-                    <select id="modify_account_select" class="form-control">
+                    <select id="modify_recipient_select" class="form-control">
                     </select>
                 </div>
-                <input type="button" value="設定" id="modify_account_button" class="btn btn-primary">
+                <input type="button" value="設定" id="modify_recipient_button" class="btn btn-primary">
             </form>
         </div>
         <div class="well">
             <form class="form-inline">
                 <div class="input-group">
                     <span class="input-group-addon">@</span>
-                    <input type="text" size="15" id="new_account_text" class="form-control">
+                    <input type="text" size="15" id="new_recipient_text" class="form-control">
                 </div>
-                <input type="button" value="新規追加" id="new_account_button" class="btn btn-primary">
+                <input type="button" value="新規追加" id="new_recipient_button" class="btn btn-primary">
             </form>
-            新規追加ボタンを押すと @<span id="permission_message_destination"></span> に以下のリプライを送り許可待ち状態になります。
+            新規追加ボタンを押すと @<span id="new_recipient"></span> に以下のリプライを送り許可待ち状態になります。
             <blockquote id="permission_message"></blockquote>
         </div>
         <h2 class="sub-header">Twitter連携</h2>

--- a/chrome_extension/javascripts/config.js
+++ b/chrome_extension/javascripts/config.js
@@ -6,133 +6,131 @@ $(() => {
         tr.children(":first").text(targetUrl);
         tr.find("input").click(() => {
             tr.remove();
-            let urlList = JSON.parse(localStorage.getItem("urlList"));
-            urlList.splice(urlList.findIndex(url => url == targetUrl), 1);
-            localStorage.setItem("urlList", JSON.stringify(urlList));
+            modifyConfig(config => {
+                config.urlList.splice(config.urlList.findIndex(url => url == targetUrl), 1);
+            });
         });
         $("#url_list > tbody").append(tr);
     }
-    for (let url of JSON.parse(localStorage.getItem("urlList"))) {
+    for (let url of loadConfig().urlList) {
         addRow(url);
     }
     $("#add_url_button").click(() => {
-        let urlList = JSON.parse(localStorage.getItem("urlList"));
-        urlList.push($("#add_url_text").val());
-        localStorage.setItem("urlList", JSON.stringify(urlList));
+        modifyConfig(config => {
+            config.urlList.push($("#add_url_text").val());
+        });
         addRow($("#add_url_text").val());
         $("#add_url_text").val("");
     });
 
-    function flushReplyAccount() {
-        let replyAccountId = JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountId;
-        (replyAccountId == -1 ? Promise.resolve("無し") : getScreenName(replyAccountId)).then(screenName => {
-            $("#account").text(`現在の宛先: ${screenName}`);
+    function flushCurrentRecipient() {
+        let recipientId = loadConfig().replySetting[loadConfig().authInfo.userId].recipientId;
+        (recipientId === null ? Promise.resolve("無し") : getScreenName(recipientId)).then(screenName => {
+            $("#current_recipient").text(`現在の宛先: ${screenName}`);
         });
     }
-    function flushReplyAccounts() {
-        let myReplySetting = JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")];
-        $("#modify_account_select").empty();
-        $("#modify_account_select").append($('<option value="-1">無し</option>'));
+    function flushRecipients() {
+        let myReplySetting = loadConfig().replySetting[loadConfig().authInfo.userId];
+        $("#modify_recipient_select").empty();
+        $("#modify_recipient_select").append($('<option value="null">無し</option>'));
         Promise.all([].concat(
-            myReplySetting.replyAccountIds.map(replyAccountId =>
-                getScreenName(replyAccountId).then(screenName =>
-                    Promise.resolve($(document.createElement("option")).attr("value", replyAccountId).text(screenName))
+            myReplySetting.recipientIds.map(recipientId =>
+                getScreenName(recipientId).then(screenName =>
+                    Promise.resolve($(document.createElement("option")).attr("value", recipientId).text(screenName))
                 )
             ),
-            Object.keys(myReplySetting.replyIdForPermissionMap).map(replyAccountId =>
-                getScreenName(replyAccountId).then(screenName =>
-                    Promise.resolve($(document.createElement("option")).attr("value", replyAccountId).prop("disabled", true).text(`${screenName}（許可待ち）`))
+            Object.keys(myReplySetting.replyIdForPermissionMap).map(str => parseInt(str, 10)).map(recipientId =>
+                getScreenName(recipientId).then(screenName =>
+                    Promise.resolve($(document.createElement("option")).attr("value", recipientId).prop("disabled", true).text(`${screenName}（許可待ち）`))
                 )
             )
         )).then(options => {
             options.sort((x, y) => x.text() < y.text() ? 1 : -1);
             for (let option of options) {
-                $("#modify_account_select").append(option);
+                $("#modify_recipient_select").append(option);
             }
-            $("#modify_account_select").val(myReplySetting.replyAccountId);
+            $("#modify_recipient_select").val(String(myReplySetting.recipientId));
         });
     }
-    flushReplyAccount();
+    flushCurrentRecipient();
     getMentions().then(statuses => {
-        let replySetting = JSON.parse(localStorage.getItem("replySetting"));
-        let myReplySetting = replySetting[localStorage.getItem("userId")];
+        let config = loadConfig();
+        let myReplySetting = config.replySetting[config.authInfo.userId];
 
-        let replyIdToUserId = {};
-        for (let userId of Object.keys(myReplySetting.replyIdForPermissionMap).map(str => parseInt(str, 10))) {
-            let replyId = myReplySetting.replyIdForPermissionMap[userId];
-            replyIdToUserId[replyId] = userId;
+        let replyIdToRecipientId = {};
+        for (let recipientId of Object.keys(myReplySetting.replyIdForPermissionMap).map(str => parseInt(str, 10))) {
+            let replyId = myReplySetting.replyIdForPermissionMap[recipientId];
+            replyIdToRecipientId[replyId] = recipientId;
         }
 
         for (let status of statuses) {
-            if (replyIdToUserId.hasOwnProperty(status["in_reply_to_status_id"]) && replyIdToUserId[status["in_reply_to_status_id"]] == status["user"]["id"]) {
-                let userId = replyIdToUserId[status["in_reply_to_status_id"]];
-                delete myReplySetting.replyIdForPermissionMap[userId];
-                myReplySetting.replyAccountIds.push(userId);
-                getScreenName(userId).then(screenName => {
+            if (replyIdToRecipientId.hasOwnProperty(status["in_reply_to_status_id"]) && replyIdToRecipientId[status["in_reply_to_status_id"]] == status["user"]["id"]) {
+                let recipientId = replyIdToRecipientId[status["in_reply_to_status_id"]];
+                delete myReplySetting.replyIdForPermissionMap[recipientId];
+                myReplySetting.recipientIds.push(recipientId);
+                getScreenName(recipientId).then(screenName => {
                     notificate(`@${screenName}からリプライの許可が下りました`, 5);
                 });
             }
         }
 
-        localStorage.setItem("replySetting", JSON.stringify(replySetting));
-    }).catch(() => Promise.resolve()).then(flushReplyAccounts);
-    $("#modify_account_button").click(() => {
-        let replySetting = JSON.parse(localStorage.getItem("replySetting"));
-        replySetting[localStorage.getItem("userId")].replyAccountId = parseInt($("#modify_account_select").val(), 10);
-        localStorage.setItem("replySetting", JSON.stringify(replySetting));
-        flushReplyAccount();
+        saveConfig(config);
+    }).catch(() => Promise.resolve()).then(flushRecipients);
+    $("#modify_recipient_button").click(() => {
+        modifyConfig(config => {
+            config.replySetting[config.authInfo.userId].recipientId = ($("#modify_recipient_select").val() == "null" ? null : parseInt($("#modify_recipient_select").val(), 10));
+        });
+        flushCurrentRecipient();
     });
 
-    $("#new_account_text").on("keydown", () => {
+    $("#new_recipient_text").on("keydown", () => {
         setTimeout(() => {
-            $("#new_account_button").prop("disabled", $("#new_account_text").val() == "");
-            $("#permission_message_destination").text($("#new_account_text").val());
-            $("#permission_message").text(sprintf(TWEET_PHRASES.GET_PERMISSION, {recipient: $("#new_account_text").val()}));
+            $("#new_recipient_button").prop("disabled", $("#new_recipient_text").val() == "");
+            $("#new_recipient").text($("#new_recipient_text").val());
+            $("#permission_message").text(sprintf(TWEET_PHRASES.GET_PERMISSION, {recipient: $("#new_recipient_text").val()}));
         }, 0);
     });
-    $("#new_account_text").trigger("keydown");
-    $("#new_account_button").click(() => {
-        let screenName = $("#new_account_text").val();
-        $("#new_account_text").val("");
-        $("#new_account_text").trigger("keydown");
-        getUserId(screenName).then(userId => {
-            if (JSON.parse(localStorage.getItem("replySetting"))[localStorage.getItem("userId")].replyAccountIds.indexOf(userId) > -1) {
-                notificate(`@${screenName}からは既に許可を得ています`, 5);
-            } else {
-                return tweet(sprintf(TWEET_PHRASES.GET_PERMISSION, {recipient: screenName})).then(status => {
-                    let replySetting = JSON.parse(localStorage.getItem("replySetting"));
-                    replySetting[localStorage.getItem("userId")].replyIdForPermissionMap[userId] = status["id"];
-                    localStorage.setItem("replySetting", JSON.stringify(replySetting));
-                    flushReplyAccounts();
+    $("#new_recipient_text").trigger("keydown");
+    $("#new_recipient_button").click(() => {
+        let screenName = $("#new_recipient_text").val();
+        $("#new_recipient_text").val("");
+        $("#new_recipient_text").trigger("keydown");
+        getUserId(screenName).then(recipientId => {
+            if (loadConfig().replySetting[loadConfig().authInfo.userId].recipientIds.indexOf(recipientId) == -1) {
+                let message = sprintf(TWEET_PHRASES.GET_PERMISSION, {recipient: screenName});
+                return tweet(message).then(status => {
+                    modifyConfig(config => {
+                        config.replySetting[config.authInfo.userId].replyIdForPermissionMap[recipientId] = status["id"];
+                    });
+                    flushRecipients();
                     notificate(`@${screenName}にリプライを送りました`, 5);
                 });
+            } else {
+                notificate(`@${screenName}からは既に許可を得ています`, 5);
             }
         }).catch(e => { alert(e.message); });
     });
 
     $("#oauth_button").click(onOAuthButtonClickHandler);
 
+    $("#tweet_tab_info_checkbox").prop("checked", loadConfig().tweetTabInfo);
     $("#tweet_tab_info_checkbox").change(function () {
-        if ($(this).is(":checked")) {
-            localStorage.setItem("tweetTabInfo", "True");
-        } else {
-            localStorage.setItem("tweetTabInfo", "False");
-        }
+        let newValue = $(this).is(":checked");
+        modifyConfig(config => {
+            config.tweetTabInfo = newValue;
+        });
     });
-    if (localStorage.getItem("tweetTabInfo") === "True") {
-        $("#tweet_tab_info_checkbox").prop("checked", true);
-    }
-    
+
+    $("#show_register_ngsite_button_checkbox").prop("checked", loadConfig().showRegisterNgSiteButton);
     $("#show_register_ngsite_button_checkbox").change(function () {
-        if ($(this).is(":checked")) {
-            localStorage.setItem("showRegisterNgSiteButton", "True");
+        let newValue = $(this).is(":checked");
+        modifyConfig(config => {
+            config.showRegisterNgSiteButton = newValue;
+        });
+        if (newValue) {
             createRegisterNgSiteButton();
         } else {
-            localStorage.setItem("showRegisterNgSiteButton", "False");
             chrome.contextMenus.removeAll();
         }
     });
-    if (localStorage.getItem("showRegisterNgSiteButton") === "True") {
-        $("#show_register_ngsite_button_checkbox").prop("checked", true);
-    }
 });

--- a/chrome_extension/javascripts/mocking.js
+++ b/chrome_extension/javascripts/mocking.js
@@ -34,27 +34,29 @@ if (location.protocol != "chrome-extension:") {
             create() {}
         }
     };
-    window.getMentions = () => Promise.resolve([]);
-    window.getScreenName = userId => Promise.resolve({
-        "3315564288": "UGEN_bot",
-        "3356282660": "UGEN_teacher"
-    }[userId]);
-    window.getUserId = screenName => Promise.resolve({
-        "UGEN_bot": 3315564288,
-        "UGEN_teacher": 3356282660
-    }[screenName]);
-    window.notificate = () => {};
-    window.getCurrentTab = () => Promise.resolve({
-        id: 0,
-        windowId: 0,
-        url: "http://example.com/",
-        title: "Example"
-    });
     (() => {
         let original$ = window.$;
         let onloadFuncs = [];
         window.$ = onloadFunc => {
             onloadFuncs.push(onloadFunc);
+        };
+        window.$.setUp = () => {
+            window.getMentions = () => Promise.resolve([]);
+            window.getScreenName = userId => Promise.resolve({
+                "3315564288": "UGEN_bot",
+                "3356282660": "UGEN_teacher"
+            }[userId]);
+            window.getUserId = screenName => Promise.resolve({
+                "UGEN_bot": 3315564288,
+                "UGEN_teacher": 3356282660
+            }[screenName]);
+            window.notificate = () => {};
+            window.getCurrentTab = () => Promise.resolve({
+                id: 0,
+                windowId: 0,
+                url: "http://example.com/",
+                title: "Example"
+            });
         };
         window.$.fire = () => {
             window.$ = original$;

--- a/chrome_extension/javascripts/pin.js
+++ b/chrome_extension/javascripts/pin.js
@@ -16,18 +16,20 @@ $(() => {
             token: queryMap["oauth_token"],
             tokenSecret: queryMap["oauth_token_secret"]
         }).then(accessTokenMap => {
-            localStorage.setItem("accessToken", accessTokenMap["oauth_token"]);
-            localStorage.setItem("accessTokenSecret", accessTokenMap["oauth_token_secret"]);
-            localStorage.setItem("userId", accessTokenMap["user_id"]);
-            let replySetting = JSON.parse(localStorage.getItem("replySetting"));
-            if (!replySetting.hasOwnProperty(accessTokenMap["user_id"])) {
-                replySetting[accessTokenMap["user_id"]] = {
-                    replyAccountId: -1,
-                    replyAccountIds: [],
-                    replyIdForPermissionMap: {}
+            modifyConfig(config => {
+                config.authInfo = {
+                    userId: parseInt(accessTokenMap["user_id"], 10),
+                    accessToken: accessTokenMap["oauth_token"],
+                    accessTokenSecret: accessTokenMap["oauth_token_secret"]
                 };
-                localStorage.setItem("replySetting", JSON.stringify(replySetting));
-            }
+                if (!config.replySetting.hasOwnProperty(config.authInfo.userId)) {
+                    config.replySetting[config.authInfo.userId] = {
+                        recipientId: null,
+                        recipientIds: [],
+                        replyIdForPermissionMap: {}
+                    };
+                }
+            });
             $("body > p").text("Twitter連携の設定が完了しました。");
             setTimeout(close, 2000);
         }).catch(e => {

--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -26,7 +26,7 @@ $(() => {
             on: "#running_image",
         }[bg.timerState]).css("display", "block");
        
-        if(getLocalStorageData("userId") === null) {
+        if (loadConfig().authInfo === null) {
             $("#guide_message").text("Twitter連携をしてね！");
             $("#start_control").css("display", "none");
             $("#oauth_control").css("display", "block");

--- a/chrome_extension/pin.html
+++ b/chrome_extension/pin.html
@@ -6,8 +6,8 @@
 <script type="text/javascript" src="lib/jquery-1.11.3.min.js"></script>
 <script type="text/javascript" src="lib/sha1.js"></script>
 <script type="text/javascript" src="lib/oauth.js"></script>
-<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/mocking.js"></script>
+<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/pin.js"></script>
 </head>
 <body>

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -9,8 +9,8 @@
 <script type="text/javascript" src="lib/oauth.js"></script>
 <script type="text/javascript" src="lib/sprintf.min.js"></script>
 <script type="text/javascript" src="javascripts/tweet_phrases.js"></script>
-<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/mocking.js"></script>
+<script type="text/javascript" src="javascripts/common.js"></script>
 <script type="text/javascript" src="javascripts/popup.js"></script>
 <link rel="stylesheet" href="lib/bootstrap/bootstrap.min.css" type="text/css">
 <link rel="stylesheet" href="popup.css" type="text/css">

--- a/chrome_extension/spec/javascripts/basic_spec.js
+++ b/chrome_extension/spec/javascripts/basic_spec.js
@@ -4,24 +4,31 @@ describe("基本機能", () => {
     let background;
     let popup;
     function setMock(globalObject, mock) {
+        globalObject.$.setUp();
         $.extend(true, globalObject, mock);
         globalObject.$.fire();
     }
     beforeEach(done => {
         let prefix = location.protocol == "http:" ? "base/" : "";
         localStorage.clear();
-        localStorage.setItem("userId", "3315564288");
-        localStorage.setItem("replySetting", JSON.stringify({
-            "3315564288": {
-                replyAccountId: -1,
-                replyAccountIds: [],
-                replyIdForPermissionMap: {}
-            }
-        }));
         jasmine.getFixtures().fixturesPath = `${prefix}spec/javascripts/fixtures`;
         loadFixtures("fixture.html");
         $("#background").load(() => {
             background = $("#background").get(0).contentWindow;
+            background.$(() => {
+                background.modifyConfig(config => {
+                    config.authInfo = {
+                        userId: 3315564288,
+                        accessToken: null,
+                        accessTokenSecret: null
+                    };
+                    config.replySetting["3315564288"] = {
+                        recipientId: null,
+                        recipientIds: [],
+                        replyIdForPermissionMap: {}
+                    };
+                });
+            });
             $("#popup").load(() => {
                 popup = $("#popup").get(0).contentWindow;
                 popup.chrome.extension.getBackgroundPage = () => background;


### PR DESCRIPTION
- 毎回 `JSON.parse()` と `JSON.stringify()` するのが煩わしいので `localStorage.getItem("config")` にデータをまとめて保存するようにして、ユーティリティ関数 `loadConfig` 、 `saveConfig` 、 `modifyConfig` を作成
- 設定データのマイグレーション用に設定データのバージョンを表す `loadConfig().version` を導入
- replyAccountIdとreplyAccountIdsをそれぞれrecipientIdとrecipientIdsに名称変更
- リプライ先を設定していない状態を示す値を-1からnullに変更