### PR TITLE
タスク完了ボタンを押すとツイート確認ダイアログが一瞬で消えるバグの修正

### DIFF
--- a/chrome_extension/javascripts/popup.js
+++ b/chrome_extension/javascripts/popup.js
@@ -78,7 +78,7 @@ $(() => {
                 }
             }
         );
-        if (loadConfig().postAutomatically.successed || confirmTweet(message, true)) {
+        if (loadConfig().postAutomatically.successed || bg.confirmTweet(message, true)) {
             bg.tweet(message).then(() => { bg.notificate("tweetしたよ^_^", 5); }).catch(e => { bg.alert(e.message); });
         }
         bg.saveTaskLog(true);

--- a/chrome_extension/spec/javascripts/advanced_spec.js
+++ b/chrome_extension/spec/javascripts/advanced_spec.js
@@ -313,18 +313,17 @@ describe("詳細設定から設定できる機能", () => {
     });
     it("タスクが見積もり時間内に終わったとき確認ダイアログを出さずにツイートする", done => {
         setMock(background, {
+            confirmTweet(message) {
+                fail("confirmTweet()が呼ばれた");
+                return true;
+            },
             tweet(message) {
                 expect(message).toContain("1分かかると見積もった作業を0分で終えました");
                 setTimeout(done, 0);
                 return Promise.resolve();
             }
         });
-        setMock(popup, {
-            confirmTweet(message) {
-                fail("confirmTweet()が呼ばれた");
-                return true;
-            }
-        });
+        setMock(popup, {});
         setMock(config, {});
         config.$("#post_automatically_checkbox_group input[data-property='successed']").click();
         popup.$("#task_time_text").val("1");

--- a/chrome_extension/spec/javascripts/basic_spec.js
+++ b/chrome_extension/spec/javascripts/basic_spec.js
@@ -53,18 +53,17 @@ describe("基本機能", () => {
     });
     it("タスクが見積もり時間内に終わったときツイートを拒否できる", done => {
         setMock(background, {
+            confirmTweet(message) {
+                expect(message).toContain("1分かかると見積もった作業を0分で終えました");
+                setTimeout(done, 0);
+                return false;
+            },
             tweet(message) {
                 fail("tweet()が呼ばれた")
                 return Promise.resolve();
             }
         });
-        setMock(popup, {
-            confirmTweet(message) {
-                expect(message).toContain("1分かかると見積もった作業を0分で終えました");
-                setTimeout(done, 0);
-                return false;
-            }
-        });
+        setMock(popup, {});
         popup.$("#task_time_text").val("1");
         popup.$("#start_button").click();
         popup.$("#end_button").click();


### PR DESCRIPTION
#88 の修正